### PR TITLE
FIX: remove hard-coded libstdc++

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,16 @@ environment:
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_ARCHS: x86_64
         - MINGW_CONFIGURATIONS: "6.3@x86_64@seh@posix"
         - MINGW_CONFIGURATIONS: "7.1@x86_64@seh@posix"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -55,10 +55,6 @@ class IcuConan(ConanFile):
             if self.settings.compiler != "Visual Studio":
                 self.build_requires("mingw_installer/1.0@conan/stable")
 
-    def configure(self):
-        if self.settings.compiler in [ "gcc", "clang" ]:
-            self.settings.compiler.libcxx = 'libstdc++11'
-
     def source(self):
         self.output.info("Fetching sources: {0}".format(self.source_url))
         tools.get("{0}".format(self.source_url))


### PR DESCRIPTION
In our setup we use a non-standard clang installation on macOS which comes with `libc++`. Hence, my default conan profile looks like that:

```
[...]
[settings]
os=Macos
[...]
compiler=clang
compiler.version=6.0
compiler.libcxx=libc++
[...]
```

Hence, all my conan dependencies are built against `libc++` (rather than `libstdc++`). Since this package hard-coded `libstdc++` for `clang` it didn't build for me.

When looking into the history of the adapted code, I found that `apple-clang` was actually removed from this hardcoded list before (presumably for a similar reason?). Unfortunately my non-standard compiler is classified as `clang` rather than `apple-clang`.

Bottom line: I'd argue that hard-coding the STL implementation to be used when building a conan dependency is never a good idea.