### PR TITLE
Update to ICU 65.1

### DIFF
--- a/icu_base.py
+++ b/icu_base.py
@@ -110,9 +110,8 @@ class ICUBase(ConanFile):
         self._install_name_tool()
 
     def package(self):
-        if self._is_msvc:
-            for dll in glob.glob( os.path.join( self.package_folder, 'lib', '*.dll' ) ):
-                shutil.move( dll, os.path.join( self.package_folder, 'bin' ) )
+        for dll in glob.glob( os.path.join( self.package_folder, 'lib', '*.dll' ) ):
+            shutil.move( dll, os.path.join( self.package_folder, 'bin' ) )
 
         self.copy("LICENSE", dst="licenses", src=os.path.join(self.source_folder, self._source_subfolder))
 

--- a/icu_base.py
+++ b/icu_base.py
@@ -50,17 +50,6 @@ class ICUBase(ConanFile):
                   sha256="53e37466b3d6d6d01ead029e3567d873a43a5d1c668ed2278e253b683136d948")
         os.rename("icu", self._source_subfolder)
 
-    def _replace_pythonpath(self):
-        if self._is_msvc:
-            srcdir = os.path.join(self.build_folder, self._source_subfolder, "source")
-            configure = os.path.join(self._source_subfolder, "source", "configure")
-            tools.replace_in_file(configure,
-                                  'PYTHONPATH="$srcdir/data"',
-                                  'PYTHONPATH="%s\\data"' % srcdir)
-            tools.replace_in_file(configure,
-                                  'PYTHONPATH="$srcdir/test/testdata:$srcdir/data"',
-                                  'PYTHONPATH="%s\\test\\testdata;%s\\data"' % (srcdir, srcdir))
-
     def _workaround_icu_20545(self):
         if tools.os_info.is_windows:
             # https://unicode-org.atlassian.net/projects/ICU/issues/ICU-20545
@@ -84,7 +73,6 @@ class ICUBase(ConanFile):
             tools.replace_in_file(run_configure_icu_file, "-MDd", flags)
             tools.replace_in_file(run_configure_icu_file, "-MD", flags)
 
-        self._replace_pythonpath() # ICU 64.1
         self._workaround_icu_20545()
 
         self._env_build = AutoToolsBuildEnvironment(self)

--- a/icu_base.py
+++ b/icu_base.py
@@ -153,7 +153,8 @@ class ICUBase(ConanFile):
                 "--with-library-bits={0}".format(bits),
                 "--disable-samples",
                 "--disable-layout",
-                "--disable-layoutex"]
+                "--disable-layoutex",
+                "--disable-extras"]
 
         if self.cross_building:
             if self._env_build.build:

--- a/icu_base.py
+++ b/icu_base.py
@@ -6,7 +6,7 @@ from conans import ConanFile, tools, AutoToolsBuildEnvironment
 
 
 class ICUBase(ConanFile):
-    version = "64.2"
+    version = "65.1"
     homepage = "http://site.icu-project.org"
     license = "ICU"
     description = "ICU is a mature, widely used set of C/C++ and Java libraries " \
@@ -47,7 +47,7 @@ class ICUBase(ConanFile):
         source_url = "https://github.com/unicode-org/icu/releases/download/release-{0}/icu4c-{1}-src.tgz".format(version, version_with_underscore)
         self.output.info("Downloading {0} ...".format(source_url))
         tools.get(source_url,
-                  sha256="627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c")
+                  sha256="53e37466b3d6d6d01ead029e3567d873a43a5d1c668ed2278e253b683136d948")
         os.rename("icu", self._source_subfolder)
 
     def _replace_pythonpath(self):


### PR DESCRIPTION
Patch "Add --disable-extras as a workaround for MSVC build issue" needs a replacement, because `uconv` utility is built as a part of extras and is needed for cross-compilation with icu_installer.